### PR TITLE
refactor: centralize configuration and async command loading

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,18 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const requiredEnvVars = ['APP_ID', 'APP_SECRET', 'ENCRYPT_KEY', 'VERIFY_TOKEN'];
+for (const envVar of requiredEnvVars) {
+  if (!process.env[envVar]) {
+    throw new Error(`Missing required environment variable: ${envVar}`);
+  }
+}
+
+export const APP_ID = process.env.APP_ID;
+export const APP_SECRET = process.env.APP_SECRET;
+export const ENCRYPT_KEY = process.env.ENCRYPT_KEY;
+export const VERIFY_TOKEN = process.env.VERIFY_TOKEN;
+export const PORT = process.env.PORT || 3000;
+export const NODE_ENV = process.env.NODE_ENV || 'development';
+export const DEFAULT_ADMINS = process.env.DEFAULT_ADMINS || '';

--- a/index.js
+++ b/index.js
@@ -4,27 +4,15 @@ import bodyParser from 'body-parser';
 import * as lark from '@larksuiteoapi/node-sdk';
 import CommandHandler from './modules/commandHandler.js';
 import UserManager from './modules/userManager.js';
-import dotenv from 'dotenv';
-
-// Load environment variables
-dotenv.config();
-
-// ⚙️ Cấu hình từ environment variables
-const APP_ID = process.env.APP_ID;
-const APP_SECRET = process.env.APP_SECRET;
-const ENCRYPT_KEY = process.env.ENCRYPT_KEY;
-const VERIFY_TOKEN = process.env.VERIFY_TOKEN;
-const PORT = process.env.PORT || 3000;
-
-// Kiểm tra required environment variables
-const requiredEnvVars = ['APP_ID', 'APP_SECRET', 'ENCRYPT_KEY', 'VERIFY_TOKEN'];
-for (const envVar of requiredEnvVars) {
-  if (!process.env[envVar]) {
-    console.error(`❌ Missing required environment variable: ${envVar}`);
-    console.error('💡 Please check your .env file or environment configuration');
-    process.exit(1);
-  }
-}
+import {
+  APP_ID,
+  APP_SECRET,
+  ENCRYPT_KEY,
+  VERIFY_TOKEN,
+  PORT,
+  NODE_ENV,
+  DEFAULT_ADMINS
+} from './config.js';
 
 // 🚀 Khởi tạo các components
 const client = new lark.Client({
@@ -35,7 +23,7 @@ const client = new lark.Client({
   disableTokenCache: process.env.DISABLE_TOKEN_CACHE === 'true'
 });
 
-const commandHandler = new CommandHandler('!'); // Prefix: !
+const commandHandler = await new CommandHandler('!').init(); // Prefix: !
 const userManager = UserManager.getInstance(); // Sử dụng singleton
 
 // 🧠 Bộ nhớ tạm để chống lặp message với automatic cleanup
@@ -126,7 +114,7 @@ const app = express();
 app.use(bodyParser.json());
 
 // 📥 Log webhook requests (simplified)
-if (process.env.NODE_ENV === 'development') {
+if (NODE_ENV === 'development') {
   app.use((req, res, next) => {
     console.log('📥 Webhook received');
     next();
@@ -150,6 +138,6 @@ app.listen(PORT, () => {
   console.log(`✅ Server running at http://localhost:${PORT}`);
   console.log(`🎮 Command prefix: ${commandHandler.prefix}`);
   console.log(`📁 Commands loaded: ${userCommands} user + ${totalAdminOnly} admin = ${adminCommands} total`);
-  console.log(`🔒 Environment: ${process.env.NODE_ENV || 'development'}`);
-  console.log(`🔐 Default admins: ${process.env.DEFAULT_ADMINS || 'none'}`);
+  console.log(`🔒 Environment: ${NODE_ENV}`);
+  console.log(`🔐 Default admins: ${DEFAULT_ADMINS || 'none'}`);
 });

--- a/modules/commandHandler.js
+++ b/modules/commandHandler.js
@@ -9,7 +9,11 @@ class CommandHandler {
     this.commands = new Map();
     this.commandStats = new Map(); // Track command usage
     this.userManager = UserManager.getInstance();
-    this.loadCommands();
+  }
+
+  async init() {
+    await this.loadCommands();
+    return this;
   }
 
   // 📂 Load tất cả commands từ thư mục commands/

--- a/modules/userManager.js
+++ b/modules/userManager.js
@@ -1,6 +1,7 @@
 // modules/userManager.js
 import fs from 'fs';
 import path from 'path';
+import { DEFAULT_ADMINS } from '../config.js';
 
 class UserManager {
   static instance = null;
@@ -17,7 +18,7 @@ class UserManager {
     this.saveTimeout = null; // Debounce saves
     
     // Default admin list from environment variable
-    this.defaultAdmins = (process.env.DEFAULT_ADMINS || '').split(',').filter(id => id.trim());
+    this.defaultAdmins = DEFAULT_ADMINS.split(',').filter(id => id.trim());
     
     UserManager.instance = this;
   }


### PR DESCRIPTION
## Summary
- centralize environment variable handling in a new `config.js`
- ensure commands are loaded asynchronously before the bot starts
- share configuration for default admins across modules

## Testing
- `node --check index.js`
- `node --check modules/commandHandler.js`
- `node --check modules/userManager.js`
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_689580b67c608323a8bd0e8314aa284c