### PR TITLE
Allow running skill tests without credentials

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,16 +3,21 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const requiredEnvVars = ['APP_ID', 'APP_SECRET', 'ENCRYPT_KEY', 'VERIFY_TOKEN'];
-for (const envVar of requiredEnvVars) {
-  if (!process.env[envVar]) {
-    throw new Error(`Missing required environment variable: ${envVar}`);
+
+// Skip strict environment variable validation when running tests
+if (process.env.NODE_ENV !== 'test') {
+  for (const envVar of requiredEnvVars) {
+    if (!process.env[envVar]) {
+      throw new Error(`Missing required environment variable: ${envVar}`);
+    }
   }
 }
 
-export const APP_ID = process.env.APP_ID;
-export const APP_SECRET = process.env.APP_SECRET;
-export const ENCRYPT_KEY = process.env.ENCRYPT_KEY;
-export const VERIFY_TOKEN = process.env.VERIFY_TOKEN;
+// Provide empty string defaults to avoid undefined values during tests
+export const APP_ID = process.env.APP_ID || '';
+export const APP_SECRET = process.env.APP_SECRET || '';
+export const ENCRYPT_KEY = process.env.ENCRYPT_KEY || '';
+export const VERIFY_TOKEN = process.env.VERIFY_TOKEN || '';
 export const PORT = process.env.PORT || 3000;
 export const NODE_ENV = process.env.NODE_ENV || 'development';
 export const DEFAULT_ADMINS = process.env.DEFAULT_ADMINS || '';

--- a/final_skill_test.js
+++ b/final_skill_test.js
@@ -1,6 +1,13 @@
 // Final skill system test
 console.log('🔥 FINAL SKILL SYSTEM TEST');
 
+// Provide default environment variables so config can load in test environment
+process.env.NODE_ENV = 'test';
+process.env.APP_ID = process.env.APP_ID || 'test';
+process.env.APP_SECRET = process.env.APP_SECRET || 'test';
+process.env.ENCRYPT_KEY = process.env.ENCRYPT_KEY || 'test';
+process.env.VERIFY_TOKEN = process.env.VERIFY_TOKEN || 'test';
+
 // Simulate wb command execution
 const mockWbCommand = {
   async execute({ userId, args }) {


### PR DESCRIPTION
## Summary
- Skip strict environment variable checks when running tests
- Add default env vars in skill test script

## Testing
- `node final_skill_test.js`


------
https://chatgpt.com/codex/tasks/task_e_689582d155ac8323885344a5476cab03