### PR TITLE
refactor wb save with async lock

### DIFF
--- a/modules/commands/wb/pve.js
+++ b/modules/commands/wb/pve.js
@@ -32,7 +32,7 @@ export default async function handlePve({ userId, args }) {
         wbUser.mp -= skill.mp_cost;
         wbUser.skillCooldowns = wbUser.skillCooldowns || {};
         wbUser.skillCooldowns[skillId] = skill.cooldown;
-        wbManager.saveUsers();
+        await wbManager.saveUsers();
         // Thực hiện hiệu ứng skill
         switch (skill.effect) {
             case 'double_attack':
@@ -47,7 +47,7 @@ export default async function handlePve({ userId, args }) {
                 const maxHp = wbUser.maxHp + stats.hpBonus;
                 const heal = Math.floor(maxHp * 0.3);
                 wbUser.hp = Math.min(maxHp, wbUser.hp + heal);
-                wbManager.saveUsers();
+                await wbManager.saveUsers();
                 combatLog.push(`💚 Bạn dùng ${skill.name}! Hồi ${heal} HP (${wbUser.hp}/${maxHp})`);
                 playerDamage = 0;
                 skillMessage = ` (Kỹ năng: ${skill.name})`;

--- a/modules/commands/wb/pvp.js
+++ b/modules/commands/wb/pvp.js
@@ -134,7 +134,7 @@ async function handlePvpChallenge(challengerId, targetId) {
   challenger.pvp.challenges.sent = { to: targetId, timestamp };
   targetWbUser.pvp.challenges.received = { from: challengerId, timestamp };
   
-  wbManager.saveUsers();
+  await wbManager.saveUsers();
   
   return `⚔️ **THÁCH ĐẤU ĐÃ GỬI!**
 Đã thách đấu **${targetId}** (Lv.${targetWbUser.level})
@@ -165,14 +165,14 @@ async function handlePvpAccept(userId) {
   const timeLeft = Math.max(0, 60 - Math.floor((Date.now() - challenge.timestamp) / 1000));
   if (timeLeft <= 0) {
     user.pvp.challenges.received = null;
-    wbManager.saveUsers();
+    await wbManager.saveUsers();
     return '⏰ Thách đấu đã hết hạn!';
   }
   
   const challenger = wbManager.getUser(challenge.from);
   if (!challenger.pvp?.challenges?.sent || challenger.pvp.challenges.sent.to !== userId) {
     user.pvp.challenges.received = null;
-    wbManager.saveUsers();
+    await wbManager.saveUsers();
     return '❌ Thách đấu đã được hủy!';
   }
   
@@ -196,7 +196,7 @@ async function handlePvpDecline(userId) {
     challenger.pvp.challenges.sent = null;
   }
   
-  wbManager.saveUsers();
+  await wbManager.saveUsers();
   
   return `❌ **ĐÃ TỪ CHỐI THÁCH ĐẤU**
 Bạn đã từ chối thách đấu từ **${challengerId}**.`;
@@ -218,7 +218,7 @@ async function handlePvpCancel(userId) {
     target.pvp.challenges.received = null;
   }
   
-  wbManager.saveUsers();
+  await wbManager.saveUsers();
   
   return `🚫 **ĐÃ HỦY THÁCH ĐẤU**
 Đã hủy thách đấu gửi tới **${targetId}**.`;
@@ -250,7 +250,7 @@ async function startPvPCombat(player1Id, player2Id) {
   player2.pvp.currentHp = maxHp2;
   player2.hp = maxHp2; // Reset HP in main stats too
   
-  wbManager.saveUsers();
+  await wbManager.saveUsers();
   
   // Start auto combat immediately
   return await handlePvpAutoCombat(player1Id, player2Id);
@@ -399,7 +399,7 @@ async function handlePvpAutoCombat(player1Id, player2Id) {
   player2.pvp.opponent = null;
   delete player2.pvp.currentHp;
   
-  wbManager.saveUsers();
+  await wbManager.saveUsers();
   
   combatLog.push(`Trận đấu kết thúc sau ${turnCount} turns!`);
   combatLog.push(`🏆 **${winnerId}** nhận được: ${xpReward} XP và ${goldReward} xu`);

--- a/modules/commands/wb/quests.js
+++ b/modules/commands/wb/quests.js
@@ -55,7 +55,7 @@ export async function handleQuestClaim({ userId }) {
     // Mark as claimed
     wbUser.dailyQuests.completed.push(today);
     wbManager.updateStatistic(userId, 'questsCompleted', completedQuests.length);
-    wbManager.saveUsers();
+    await wbManager.saveUsers();
     
     return `🎉 **NHẬN THƯỞNG THÀNH CÔNG!**
 Đã hoàn thành ${completedQuests.length} quest và nhận được:


### PR DESCRIPTION
## Summary
- refactor worldboss data saving to use async fs and lock file
- await all worldboss `saveUsers` calls to ensure persistence

## Testing
- `npm test` *(fails: Missing script "test")*
- `node /tmp/p1.mjs & sleep 0.2 && node /tmp/p2.mjs & wait`


------
https://chatgpt.com/codex/tasks/task_e_68961d2795508323a2f01ca00f7f4061