### PR TITLE
Refactor world boss skills into modular handlers

### DIFF
--- a/modules/commands/wb/skills/__tests__/buff_atk_30_def_-20_3.test.js
+++ b/modules/commands/wb/skills/__tests__/buff_atk_30_def_-20_3.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import apply from '../buff_atk_30_def_-20_3.js';
+
+test('buff_atk_30_def_-20_3 adds attack and defense buffs', () => {
+    const added = [];
+    const wbManager = { addBuff: (uid, type, amount, turns) => added.push({ type, amount, turns }) };
+    const wbUser = { combatState: {} };
+    const stats = { attack: 20 };
+    const monster = { defense: 5 };
+    const combatLog = [];
+    const state = { wbUser, stats, combatLog, wbManager, skill: { name: 'Rage' }, damage: Math.max(1, stats.attack - monster.defense) };
+    apply({ userId: 'u1', monster, state });
+    assert.equal(added.length, 2);
+    assert.equal(added[0].type, 'attack');
+    assert.equal(added[1].type, 'defense');
+    assert.ok(combatLog[0].includes('Tăng 30%'));
+});

--- a/modules/commands/wb/skills/__tests__/buff_def_40_2.test.js
+++ b/modules/commands/wb/skills/__tests__/buff_def_40_2.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import apply from '../buff_def_40_2.js';
+
+test('buff_def_40_2 adds defense buff', () => {
+    const added = [];
+    const wbManager = { addBuff: (uid, type, amount, turns) => added.push({ type, amount, turns }) };
+    const wbUser = { combatState: {} };
+    const stats = { attack: 20 };
+    const monster = { defense: 5 };
+    const combatLog = [];
+    const state = { wbUser, stats, combatLog, wbManager, skill: { name: 'Buff Def' }, damage: Math.max(1, stats.attack - monster.defense) };
+    apply({ userId: 'u1', monster, state });
+    assert.equal(added.length, 1);
+    assert.equal(added[0].type, 'defense');
+    assert.ok(combatLog[0].includes('Tăng 40%'));
+});

--- a/modules/commands/wb/skills/__tests__/double_attack.test.js
+++ b/modules/commands/wb/skills/__tests__/double_attack.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import apply from '../double_attack.js';
+
+test('double_attack doubles damage', () => {
+    const monster = { defense: 5, attack: 10, name: 'Goblin' };
+    const wbUser = { combatState: {} };
+    const stats = { attack: 20, defense: 5 };
+    const combatLog = [];
+    const state = { wbUser, stats, combatLog, skill: { name: 'Double Attack' }, damage: Math.max(1, stats.attack - monster.defense) };
+    apply({ userId: 'u1', monster, state });
+    const expected = Math.max(1, Math.floor(stats.attack * 0.8) - monster.defense) * 2;
+    assert.equal(state.damage, expected);
+    assert.ok(combatLog[0].includes('Double Attack'));
+});

--- a/modules/commands/wb/skills/__tests__/fireball.test.js
+++ b/modules/commands/wb/skills/__tests__/fireball.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import apply from '../fireball.js';
+
+test('fireball deals magic damage', () => {
+    const monster = { defense: 10, attack: 5, name: 'Slime' };
+    const wbUser = { combatState: {} };
+    const stats = { attack: 20 };
+    const combatLog = [];
+    const state = { wbUser, stats, combatLog, skill: { name: 'Fireball' }, damage: Math.max(1, stats.attack - monster.defense) };
+    apply({ userId: 'u1', monster, state });
+    const expected = Math.max(1, Math.floor(stats.attack * 1.5) - Math.floor(monster.defense * 0.8));
+    assert.equal(state.damage, expected);
+    assert.ok(combatLog[0].includes('Gây'));
+});

--- a/modules/commands/wb/skills/__tests__/heal_30.test.js
+++ b/modules/commands/wb/skills/__tests__/heal_30.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import apply from '../heal_30.js';
+
+test('heal_30 restores 30% HP', async () => {
+    const monster = { hp: 100 };
+    const wbManager = { saveUsers: async () => {} };
+    const wbUser = { maxHp: 100, hp: 50 };
+    const stats = { hpBonus: 0 };
+    const combatLog = [];
+    const state = { wbUser, stats, combatLog, wbManager, skill: { name: 'Heal' }, damage: 10 };
+    await apply({ userId: 'u1', monster, state });
+    assert.equal(state.damage, 0);
+    assert.equal(wbUser.hp, 80);
+    assert.ok(combatLog[0].includes('Hồi'));
+});

--- a/modules/commands/wb/skills/buff_atk_30_def_-20_3.js
+++ b/modules/commands/wb/skills/buff_atk_30_def_-20_3.js
@@ -1,0 +1,20 @@
+export default function apply({ userId, monster, state }) {
+    const { wbManager, wbUser, stats, combatLog = [], skill, isMonster = false, auto = false } = state;
+    if (isMonster) {
+        if (auto) {
+            state.autoMsg = `💢 ${skill.name}!`;
+        } else {
+            state.monsterSkillMsg = `💢 ${monster.name} dùng ${skill.name}! Tăng tấn công, giảm phòng thủ.`;
+        }
+    } else {
+        wbManager?.addBuff?.(userId, 'attack', 0.3, 3);
+        wbManager?.addBuff?.(userId, 'defense', -0.2, 3);
+        state.damage = Math.max(1, stats.attack - (wbUser.combatState.monsterBuffedDefense || monster.defense));
+        if (auto) {
+            state.autoMsg = `💢 Dùng ${skill.name}!`;
+        } else {
+            combatLog.push(`💢 Bạn dùng ${skill.name}! Tăng 30% tấn công, giảm 20% phòng thủ trong 3 lượt.`);
+            state.skillMessage = ` (Kỹ năng: ${skill.name})`;
+        }
+    }
+}

--- a/modules/commands/wb/skills/buff_def_40_2.js
+++ b/modules/commands/wb/skills/buff_def_40_2.js
@@ -1,0 +1,19 @@
+export default function apply({ userId, monster, state }) {
+    const { wbManager, wbUser, stats, combatLog = [], skill, isMonster = false, auto = false } = state;
+    if (isMonster) {
+        if (auto) {
+            state.autoMsg = `🛡️ ${skill.name}!`;
+        } else {
+            state.monsterSkillMsg = `🛡️ ${monster.name} dùng ${skill.name}! Tăng phòng thủ.`;
+        }
+    } else {
+        wbManager?.addBuff?.(userId, 'defense', 0.4, 2);
+        state.damage = Math.max(1, stats.attack - (wbUser.combatState.monsterBuffedDefense || monster.defense));
+        if (auto) {
+            state.autoMsg = `🛡️ Dùng ${skill.name}!`;
+        } else {
+            combatLog.push(`🛡️ Bạn dùng ${skill.name}! Tăng 40% phòng thủ trong 2 lượt.`);
+            state.skillMessage = ` (Kỹ năng: ${skill.name})`;
+        }
+    }
+}

--- a/modules/commands/wb/skills/double_attack.js
+++ b/modules/commands/wb/skills/double_attack.js
@@ -1,0 +1,23 @@
+export default function apply({ userId, monster, state }) {
+    const { wbUser, stats, combatLog = [], skill, isMonster = false, auto = false } = state;
+    if (isMonster) {
+        const baseDamage = Math.max(1, Math.floor((wbUser.combatState.monsterBuffedAttack || monster.attack) * 0.8) - stats.defense);
+        state.damage = baseDamage * 2;
+        if (auto) {
+            state.autoMsg = `🌀 ${skill.name}!`;
+        } else {
+            state.monsterSkillMsg = `🌀 ${monster.name} dùng ${skill.name}! Tấn công 2 lần, mỗi đòn ${baseDamage} sát thương.`;
+        }
+    } else {
+        const baseDamage = Math.max(1, Math.floor(stats.attack * 0.8) - (wbUser.combatState.monsterBuffedDefense || monster.defense));
+        state.damage = baseDamage * 2;
+        if (auto) {
+            state.autoMsg = `🌀 Dùng ${skill.name}! 2 đòn, mỗi đòn ${baseDamage} sát thương (Tổng: ${state.damage})`;
+        } else {
+            combatLog.push(`🌀 Bạn dùng ${skill.name}! Tấn công 2 lần, mỗi đòn ${baseDamage} sát thương.`);
+            combatLog.push(`💥 Đòn 1: ${baseDamage} sát thương.`);
+            combatLog.push(`💥 Đòn 2: ${baseDamage} sát thương.`);
+            state.skillMessage = ` (Kỹ năng: ${skill.name})`;
+        }
+    }
+}

--- a/modules/commands/wb/skills/fireball.js
+++ b/modules/commands/wb/skills/fireball.js
@@ -1,0 +1,19 @@
+export default function apply({ userId, monster, state }) {
+    const { wbUser, stats, combatLog = [], skill, isMonster = false, auto = false } = state;
+    if (isMonster) {
+        state.damage = Math.max(1, Math.floor((wbUser.combatState.monsterBuffedAttack || monster.attack) * 1.5) - Math.floor(stats.defense * 0.8));
+        if (auto) {
+            state.autoMsg = `🔥 ${skill.name}!`;
+        } else {
+            state.monsterSkillMsg = `🔥 ${monster.name} dùng ${skill.name}! Gây ${state.damage} sát thương phép (bỏ qua 20% phòng thủ).`;
+        }
+    } else {
+        state.damage = Math.max(1, Math.floor(stats.attack * 1.5) - Math.floor((wbUser.combatState.monsterBuffedDefense || monster.defense) * 0.8));
+        if (auto) {
+            state.autoMsg = `🔥 Dùng ${skill.name}! Gây ${state.damage} sát thương phép`;
+        } else {
+            combatLog.push(`🔥 Bạn dùng ${skill.name}! Gây ${state.damage} sát thương phép (bỏ qua 20% phòng thủ).`);
+            state.skillMessage = ` (Kỹ năng: ${skill.name})`;
+        }
+    }
+}

--- a/modules/commands/wb/skills/heal_30.js
+++ b/modules/commands/wb/skills/heal_30.js
@@ -1,0 +1,28 @@
+export default async function apply({ userId, monster, state }) {
+    const { wbUser, stats, wbManager, combatLog = [], skill, isMonster = false, auto = false } = state;
+    if (isMonster) {
+        const maxHp = wbUser.combatState.monsterMaxHp || monster.hp;
+        const heal = Math.floor(maxHp * 0.3);
+        state.monsterHp = Math.min(maxHp, (state.monsterHp || 0) + heal);
+        state.damage = 0;
+        if (auto) {
+            state.autoMsg = `💚 ${skill.name}! (+${heal} HP)`;
+        } else {
+            state.monsterSkillMsg = `💚 ${monster.name} dùng ${skill.name}! Hồi ${heal} HP.`;
+        }
+    } else {
+        const maxHp = wbUser.maxHp + (stats.hpBonus || 0);
+        const heal = Math.floor(maxHp * 0.3);
+        wbUser.hp = Math.min(maxHp, wbUser.hp + heal);
+        if (wbManager?.saveUsers) {
+            await wbManager.saveUsers();
+        }
+        state.damage = 0;
+        if (auto) {
+            state.autoMsg = `💚 Dùng ${skill.name}! Hồi ${heal} HP (${wbUser.hp}/${maxHp})`;
+        } else {
+            combatLog.push(`💚 Bạn dùng ${skill.name}! Hồi ${heal} HP (${wbUser.hp}/${maxHp})`);
+            state.skillMessage = ` (Kỹ năng: ${skill.name})`;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- modularize world boss skill effects
- use map lookup for skill effects in pve combat
- add unit tests for each skill

## Testing
- `node --test modules/commands/wb/skills/__tests__/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68961fa78f088323b10c145039506304