### PR TITLE
feat(wb): expand combat attributes and status effects

### DIFF
--- a/modules/commands/wb/info.js
+++ b/modules/commands/wb/info.js
@@ -27,6 +27,12 @@ export default async function handleInfo({ userId, args }) {
 ⭐ **Level:** ${wbUser.level}/${MAX_LEVEL} (${wbUser.xp}/${getXPRequiredForLevel(wbUser.level + 1)} XP)${wbUser.level >= MAX_LEVEL ? ' 🌟 MAX!' : ''}
 ⚔️ **Tấn công:** ${stats.attack} (Base: ${wbUser.baseAttack})
 🛡️ **Phòng thủ:** ${stats.defense} (Base: ${wbUser.baseDefense})
+🗡️ **Xuyên giáp:** ${stats.armorPen}
+🩸 **Hút máu:** ${(stats.lifesteal * 100).toFixed(0)}%
+🔮 **Phép thuật:** ${stats.magic}
+✨ **Kháng phép:** ${stats.magicResist}
+👟 **Tốc độ:** ${stats.speed}
+💨 **Né tránh:** ${(stats.dodge * 100).toFixed(0)}%
 💰 **Tiền:** ${generalUser.money}${equipmentText}${buffText}
 ⚔️ **Trạng thái:** ${wbUser.combatState.inCombat ? `Đang chiến đấu với ${wbManager.getMonster(wbUser.combatState.monsterId)?.name || 'Unknown Monster'}` : 'An toàn'}`;
 }

--- a/modules/commands/wb/skills/burn.js
+++ b/modules/commands/wb/skills/burn.js
@@ -1,0 +1,21 @@
+import { addStatus } from '../statusEffects.js';
+
+export default function apply({ userId, monster, state }) {
+  const { wbUser, combatLog = [], skill, isMonster = false, auto = false } = state;
+  if (isMonster) {
+    addStatus(wbUser, 'burn', 3);
+    if (auto) {
+      state.autoMsg = `🔥 ${skill.name}!`;
+    } else {
+      state.monsterSkillMsg = `🔥 ${monster.name} dùng ${skill.name}!`;
+    }
+  } else {
+    addStatus(wbUser.combatState, 'burn', 3, undefined, 'monsterStatusEffects');
+    if (auto) {
+      state.autoMsg = `🔥 Dùng ${skill.name}!`;
+    } else {
+      combatLog.push(`🔥 Bạn dùng ${skill.name}! Đốt cháy kẻ địch.`);
+      state.skillMessage = ` (Kỹ năng: ${skill.name})`;
+    }
+  }
+}

--- a/modules/commands/wb/skills/fireball.js
+++ b/modules/commands/wb/skills/fireball.js
@@ -1,18 +1,21 @@
 export default function apply({ userId, monster, state }) {
     const { wbUser, stats, combatLog = [], skill, isMonster = false, auto = false } = state;
     if (isMonster) {
-        state.damage = Math.max(1, Math.floor((wbUser.combatState.monsterBuffedAttack || monster.attack) * 1.5) - Math.floor(stats.defense * 0.8));
+        const magic = wbUser.combatState.monsterBuffedAttack || monster.magic || monster.attack;
+        const targetResist = stats.magicResist || 0;
+        state.damage = Math.max(1, Math.floor(magic * 1.5) - Math.floor(Math.max(0, targetResist) * 0.8));
         if (auto) {
             state.autoMsg = `🔥 ${skill.name}!`;
         } else {
-            state.monsterSkillMsg = `🔥 ${monster.name} dùng ${skill.name}! Gây ${state.damage} sát thương phép (bỏ qua 20% phòng thủ).`;
+            state.monsterSkillMsg = `🔥 ${monster.name} dùng ${skill.name}! Gây ${state.damage} sát thương phép.`;
         }
     } else {
-        state.damage = Math.max(1, Math.floor(stats.attack * 1.5) - Math.floor((wbUser.combatState.monsterBuffedDefense || monster.defense) * 0.8));
+        const targetResist = wbUser.combatState.monsterBuffedDefense || monster.magicResist || 0;
+        state.damage = Math.max(1, Math.floor(stats.magic * 1.5) - Math.floor(Math.max(0, targetResist - stats.armorPen) * 0.8));
         if (auto) {
             state.autoMsg = `🔥 Dùng ${skill.name}! Gây ${state.damage} sát thương phép`;
         } else {
-            combatLog.push(`🔥 Bạn dùng ${skill.name}! Gây ${state.damage} sát thương phép (bỏ qua 20% phòng thủ).`);
+            combatLog.push(`🔥 Bạn dùng ${skill.name}! Gây ${state.damage} sát thương phép.`);
             state.skillMessage = ` (Kỹ năng: ${skill.name})`;
         }
     }

--- a/modules/commands/wb/skills/freeze.js
+++ b/modules/commands/wb/skills/freeze.js
@@ -1,0 +1,21 @@
+import { addStatus } from '../statusEffects.js';
+
+export default function apply({ userId, monster, state }) {
+  const { wbUser, combatLog = [], skill, isMonster = false, auto = false } = state;
+  if (isMonster) {
+    addStatus(wbUser, 'freeze', 2);
+    if (auto) {
+      state.autoMsg = `❄️ ${skill.name}!`;
+    } else {
+      state.monsterSkillMsg = `❄️ ${monster.name} dùng ${skill.name}!`;
+    }
+  } else {
+    addStatus(wbUser.combatState, 'freeze', 2, undefined, 'monsterStatusEffects');
+    if (auto) {
+      state.autoMsg = `❄️ Dùng ${skill.name}!`;
+    } else {
+      combatLog.push(`❄️ Bạn dùng ${skill.name}! Đóng băng kẻ địch.`);
+      state.skillMessage = ` (Kỹ năng: ${skill.name})`;
+    }
+  }
+}

--- a/modules/commands/wb/skills/paralyze.js
+++ b/modules/commands/wb/skills/paralyze.js
@@ -1,0 +1,21 @@
+import { addStatus } from '../statusEffects.js';
+
+export default function apply({ userId, monster, state }) {
+  const { wbUser, combatLog = [], skill, isMonster = false, auto = false } = state;
+  if (isMonster) {
+    addStatus(wbUser, 'paralyze', 2);
+    if (auto) {
+      state.autoMsg = `⚡ ${skill.name}!`;
+    } else {
+      state.monsterSkillMsg = `⚡ ${monster.name} dùng ${skill.name}!`;
+    }
+  } else {
+    addStatus(wbUser.combatState, 'paralyze', 2, undefined, 'monsterStatusEffects');
+    if (auto) {
+      state.autoMsg = `⚡ Dùng ${skill.name}!`;
+    } else {
+      combatLog.push(`⚡ Bạn dùng ${skill.name}! Tê liệt kẻ địch.`);
+      state.skillMessage = ` (Kỹ năng: ${skill.name})`;
+    }
+  }
+}

--- a/modules/commands/wb/skills/poison.js
+++ b/modules/commands/wb/skills/poison.js
@@ -1,0 +1,21 @@
+import { addStatus } from '../statusEffects.js';
+
+export default function apply({ userId, monster, state }) {
+  const { wbUser, combatLog = [], skill, isMonster = false, auto = false } = state;
+  if (isMonster) {
+    addStatus(wbUser, 'poison', 3);
+    if (auto) {
+      state.autoMsg = `☠️ ${skill.name}!`;
+    } else {
+      state.monsterSkillMsg = `☠️ ${monster.name} dùng ${skill.name}!`;
+    }
+  } else {
+    addStatus(wbUser.combatState, 'poison', 3, undefined, 'monsterStatusEffects');
+    if (auto) {
+      state.autoMsg = `☠️ Dùng ${skill.name}!`;
+    } else {
+      combatLog.push(`☠️ Bạn dùng ${skill.name}! Độc sẽ gây sát thương theo thời gian.`);
+      state.skillMessage = ` (Kỹ năng: ${skill.name})`;
+    }
+  }
+}

--- a/modules/commands/wb/skills/quicksand.js
+++ b/modules/commands/wb/skills/quicksand.js
@@ -1,0 +1,21 @@
+import { addStatus } from '../statusEffects.js';
+
+export default function apply({ userId, monster, state }) {
+  const { wbUser, combatLog = [], skill, isMonster = false, auto = false } = state;
+  if (isMonster) {
+    addStatus(wbUser, 'quicksand', 3);
+    if (auto) {
+      state.autoMsg = `🕳️ ${skill.name}!`;
+    } else {
+      state.monsterSkillMsg = `🕳️ ${monster.name} dùng ${skill.name}!`;
+    }
+  } else {
+    addStatus(wbUser.combatState, 'quicksand', 3, undefined, 'monsterStatusEffects');
+    if (auto) {
+      state.autoMsg = `🕳️ Dùng ${skill.name}!`;
+    } else {
+      combatLog.push(`🕳️ Bạn dùng ${skill.name}! Làm kẻ địch sa lầy.`);
+      state.skillMessage = ` (Kỹ năng: ${skill.name})`;
+    }
+  }
+}

--- a/modules/commands/wb/skills/stun.js
+++ b/modules/commands/wb/skills/stun.js
@@ -1,0 +1,21 @@
+import { addStatus } from '../statusEffects.js';
+
+export default function apply({ userId, monster, state }) {
+  const { wbUser, combatLog = [], skill, isMonster = false, auto = false } = state;
+  if (isMonster) {
+    addStatus(wbUser, 'stun', 1);
+    if (auto) {
+      state.autoMsg = `💫 ${skill.name}!`;
+    } else {
+      state.monsterSkillMsg = `💫 ${monster.name} dùng ${skill.name}!`;
+    }
+  } else {
+    addStatus(wbUser.combatState, 'stun', 1, undefined, 'monsterStatusEffects');
+    if (auto) {
+      state.autoMsg = `💫 Dùng ${skill.name}!`;
+    } else {
+      combatLog.push(`💫 Bạn dùng ${skill.name}! Làm choáng kẻ địch.`);
+      state.skillMessage = ` (Kỹ năng: ${skill.name})`;
+    }
+  }
+}

--- a/modules/commands/wb/stats.js
+++ b/modules/commands/wb/stats.js
@@ -9,6 +9,8 @@ export default async function handleStats({ userId }) {
 👑 **Boss đã hạ gục:** ${stats.bossesKilled}
 🎁 **Vật phẩm đã tìm thấy:** ${stats.itemsFound}
 📋 **Quest đã hoàn thành:** ${stats.questsCompleted}
+⚔️ **PvP Thắng:** ${stats.pvpWins}
+💀 **PvP Thua:** ${stats.pvpLosses}
 
 🏆 **Thành tích:**
 ${stats.bossesKilled >= 10 ? '👑 **Boss Slayer** - Hạ gục 10+ boss' : ''}

--- a/modules/commands/wb/statusEffects.js
+++ b/modules/commands/wb/statusEffects.js
@@ -1,0 +1,48 @@
+export function applyStatusEffects(entity, maxHp, combatLog = [], name = '') {
+  let skipTurn = false;
+  entity.statusEffects = entity.statusEffects || [];
+  const remaining = [];
+  for (const effect of entity.statusEffects) {
+    switch (effect.type) {
+      case 'poison': {
+        const dmg = Math.floor(maxHp * 0.05);
+        entity.hp = Math.max(0, entity.hp - dmg);
+        combatLog.push(`${name} ☠️ chịu ${dmg} sát thương độc.`);
+        break;
+      }
+      case 'burn': {
+        const dmg = Math.floor(maxHp * 0.1);
+        entity.hp = Math.max(0, entity.hp - dmg);
+        combatLog.push(`${name} 🔥 bị bỏng mất ${dmg} HP.`);
+        break;
+      }
+      case 'freeze':
+        combatLog.push(`${name} ❄️ bị đóng băng và bỏ lượt!`);
+        skipTurn = true;
+        break;
+      case 'stun':
+        combatLog.push(`${name} 💫 bị choáng và bỏ lượt!`);
+        skipTurn = true;
+        break;
+      case 'paralyze':
+        if (Math.random() < 0.5) {
+          combatLog.push(`${name} ⚡ bị tê liệt và bỏ lượt!`);
+          skipTurn = true;
+        }
+        break;
+      case 'quicksand':
+        combatLog.push(`${name} 🕳️ bị sa lầy, giảm tốc độ.`);
+        entity.speed = Math.max(0, (entity.speed || 0) - (effect.value || 1));
+        break;
+    }
+    effect.turns--;
+    if (effect.turns > 0) remaining.push(effect);
+  }
+  entity.statusEffects = remaining;
+  return { skipTurn };
+}
+
+export function addStatus(target, type, turns = 2, value, key = 'statusEffects') {
+  target[key] = target[key] || [];
+  target[key].push({ type, turns, value });
+}

--- a/modules/commands/wb/utils.js
+++ b/modules/commands/wb/utils.js
@@ -134,6 +134,7 @@ export function resetCombatState() {
     monsterBuffedAttack: null,
     monsterBuffedDefense: null,
     monsterArmorPenetration: null,
-    mapId: null
+    mapId: null,
+    monsterStatusEffects: []
   };
 }

--- a/worldboss_data/skills.json
+++ b/worldboss_data/skills.json
@@ -71,5 +71,71 @@
     "effect": "passive_def_10",
     "category": "passive",
     "buyPrice": 700
+  },
+  "poison": {
+    "id": "poison",
+    "name": "Độc Tố",
+    "description": "Gây độc cho đối thủ trong 3 lượt.",
+    "mp_cost": 20,
+    "cooldown": 3,
+    "type": "active",
+    "effect": "poison",
+    "category": "attack",
+    "buyPrice": 500
+  },
+  "paralyze": {
+    "id": "paralyze",
+    "name": "Tê Liệt",
+    "description": "Làm tê liệt đối thủ, có thể khiến bỏ lượt trong 2 lượt.",
+    "mp_cost": 18,
+    "cooldown": 3,
+    "type": "active",
+    "effect": "paralyze",
+    "category": "attack",
+    "buyPrice": 500
+  },
+  "burn": {
+    "id": "burn",
+    "name": "Thiêu Đốt",
+    "description": "Gây cháy, mất HP mỗi lượt trong 3 lượt.",
+    "mp_cost": 20,
+    "cooldown": 3,
+    "type": "active",
+    "effect": "burn",
+    "category": "attack",
+    "buyPrice": 500
+  },
+  "freeze": {
+    "id": "freeze",
+    "name": "Đóng Băng",
+    "description": "Đóng băng kẻ địch, mất lượt trong 2 lượt.",
+    "mp_cost": 22,
+    "cooldown": 4,
+    "type": "active",
+    "effect": "freeze",
+    "category": "attack",
+    "buyPrice": 600
+  },
+  "stun": {
+    "id": "stun",
+    "name": "Choáng",
+    "description": "Làm choáng đối thủ 1 lượt.",
+    "mp_cost": 16,
+    "cooldown": 3,
+    "type": "active",
+    "effect": "stun",
+    "category": "attack",
+    "buyPrice": 450
+  },
+  "quicksand": {
+    "id": "quicksand",
+    "name": "Sa Lầy",
+    "description": "Giảm tốc độ của đối thủ trong 3 lượt.",
+    "mp_cost": 18,
+    "cooldown": 3,
+    "type": "active",
+    "effect": "quicksand",
+    "category": "attack",
+    "buyPrice": 500
   }
-} 
+}


### PR DESCRIPTION
## Summary
- add lifesteal, magic, magic resist, dodge, speed and armor penetration to player data and stat calculations
- display new combat attributes and support status effects like poison, burn, freeze, stun, paralyze and quicksand
- update PvE and PvP logic to use new stats and introduce skill handlers for damage-over-time and crowd control

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check modules/wbDataManager.js`
- `node --check modules/commands/wb/statusEffects.js`
- `node --check modules/commands/wb/skills/poison.js`
- `node --check modules/commands/wb/skills/burn.js`
- `node --check modules/commands/wb/skills/freeze.js`
- `node --check modules/commands/wb/skills/stun.js`
- `node --check modules/commands/wb/skills/paralyze.js`
- `node --check modules/commands/wb/skills/quicksand.js`
- `node --check modules/commands/wb/skills/fireball.js`
- `node --check modules/commands/wb/pve.js`
- `node --check modules/commands/wb/info.js`
- `node --check modules/commands/wb/pvp.js`
- `node --check modules/commands/wb/utils.js`


------
https://chatgpt.com/codex/tasks/task_e_6896332b551c8323884203b6c988ea73