### PR TITLE
Improve combat logging with skill effects

### DIFF
--- a/modules/commands/wb/pve.js
+++ b/modules/commands/wb/pve.js
@@ -87,7 +87,7 @@ export default async function handlePve({ userId, args }) {
         if (!skillId) {
             combatLog.push(`💥 Bạn tấn công ${monster.name}, gây ${playerDamage} sát thương.`);
         } else {
-            combatLog.push(`💥 Tổng sát thương lên quái: ${playerDamage}`);
+            combatLog.push(`💥 Tổng sát thương lên quái: ${playerDamage}${skillMessage}`);
         }
         // Lifesteal
         if (playerDamage > 0 && stats.lifesteal > 0) {
@@ -391,7 +391,7 @@ async function handleAutoCombat(userId, safeMode = false) {
         if (skillMsg) {
             combatLog.push(`Turn ${turnCount}: ${skillMsg}`);
         } else {
-            combatLog.push(`Turn ${turnCount}: 💥 Đánh thường! Gây ${playerDamage} sát thương`);
+            combatLog.push(`Turn ${turnCount}: 💥 Đánh thường!`);
         }
         // Player attacks monster
         currentMonsterHp -= playerDamage;

--- a/modules/commands/wb/skills/__tests__/fireball.test.js
+++ b/modules/commands/wb/skills/__tests__/fireball.test.js
@@ -3,13 +3,13 @@ import assert from 'node:assert/strict';
 import apply from '../fireball.js';
 
 test('fireball deals magic damage', () => {
-    const monster = { defense: 10, attack: 5, name: 'Slime' };
+    const monster = { magicResist: 10, attack: 5, name: 'Slime' };
     const wbUser = { combatState: {} };
-    const stats = { attack: 20 };
+    const stats = { attack: 20, magic: 20 };
     const combatLog = [];
-    const state = { wbUser, stats, combatLog, skill: { name: 'Fireball' }, damage: Math.max(1, stats.attack - monster.defense) };
+    const state = { wbUser, stats, combatLog, skill: { name: 'Fireball' }, damage: Math.max(1, stats.magic - monster.magicResist) };
     apply({ userId: 'u1', monster, state });
-    const expected = Math.max(1, Math.floor(stats.attack * 1.5) - Math.floor(monster.defense * 0.8));
+    const expected = Math.max(1, Math.floor(stats.magic * 1.5) - Math.floor(monster.magicResist * 0.8));
     assert.equal(state.damage, expected);
     assert.ok(combatLog[0].includes('Gây'));
 });

--- a/modules/commands/wb/skills/buff_atk_30_def_-20_3.js
+++ b/modules/commands/wb/skills/buff_atk_30_def_-20_3.js
@@ -2,7 +2,7 @@ export default function apply({ userId, monster, state }) {
     const { wbManager, wbUser, stats, combatLog = [], skill, isMonster = false, auto = false } = state;
     if (isMonster) {
         if (auto) {
-            state.autoMsg = `💢 ${skill.name}!`;
+            state.autoMsg = `💢 ${skill.name}! +30% tấn công, -20% phòng thủ (3 lượt)`;
         } else {
             state.monsterSkillMsg = `💢 ${monster.name} dùng ${skill.name}! Tăng tấn công, giảm phòng thủ.`;
         }
@@ -11,7 +11,7 @@ export default function apply({ userId, monster, state }) {
         wbManager?.addBuff?.(userId, 'defense', -0.2, 3);
         state.damage = Math.max(1, stats.attack - (wbUser.combatState.monsterBuffedDefense || monster.defense));
         if (auto) {
-            state.autoMsg = `💢 Dùng ${skill.name}!`;
+            state.autoMsg = `💢 Dùng ${skill.name}! +30% tấn công, -20% phòng thủ (3 lượt)`;
         } else {
             combatLog.push(`💢 Bạn dùng ${skill.name}! Tăng 30% tấn công, giảm 20% phòng thủ trong 3 lượt.`);
             state.skillMessage = ` (Kỹ năng: ${skill.name})`;

--- a/modules/commands/wb/skills/buff_def_40_2.js
+++ b/modules/commands/wb/skills/buff_def_40_2.js
@@ -2,7 +2,7 @@ export default function apply({ userId, monster, state }) {
     const { wbManager, wbUser, stats, combatLog = [], skill, isMonster = false, auto = false } = state;
     if (isMonster) {
         if (auto) {
-            state.autoMsg = `🛡️ ${skill.name}!`;
+            state.autoMsg = `🛡️ ${skill.name}! +40% phòng thủ (2 lượt)`;
         } else {
             state.monsterSkillMsg = `🛡️ ${monster.name} dùng ${skill.name}! Tăng phòng thủ.`;
         }
@@ -10,7 +10,7 @@ export default function apply({ userId, monster, state }) {
         wbManager?.addBuff?.(userId, 'defense', 0.4, 2);
         state.damage = Math.max(1, stats.attack - (wbUser.combatState.monsterBuffedDefense || monster.defense));
         if (auto) {
-            state.autoMsg = `🛡️ Dùng ${skill.name}!`;
+            state.autoMsg = `🛡️ Dùng ${skill.name}! +40% phòng thủ (2 lượt)`;
         } else {
             combatLog.push(`🛡️ Bạn dùng ${skill.name}! Tăng 40% phòng thủ trong 2 lượt.`);
             state.skillMessage = ` (Kỹ năng: ${skill.name})`;

--- a/modules/commands/wb/skills/burn.js
+++ b/modules/commands/wb/skills/burn.js
@@ -5,14 +5,14 @@ export default function apply({ userId, monster, state }) {
   if (isMonster) {
     addStatus(wbUser, 'burn', 3);
     if (auto) {
-      state.autoMsg = `🔥 ${skill.name}!`;
+      state.autoMsg = `🔥 ${skill.name}! Gây bỏng 3 lượt`;
     } else {
       state.monsterSkillMsg = `🔥 ${monster.name} dùng ${skill.name}!`;
     }
   } else {
     addStatus(wbUser.combatState, 'burn', 3, undefined, 'monsterStatusEffects');
     if (auto) {
-      state.autoMsg = `🔥 Dùng ${skill.name}!`;
+      state.autoMsg = `🔥 Dùng ${skill.name}! Gây bỏng 3 lượt`;
     } else {
       combatLog.push(`🔥 Bạn dùng ${skill.name}! Đốt cháy kẻ địch.`);
       state.skillMessage = ` (Kỹ năng: ${skill.name})`;

--- a/modules/commands/wb/skills/double_attack.js
+++ b/modules/commands/wb/skills/double_attack.js
@@ -4,7 +4,7 @@ export default function apply({ userId, monster, state }) {
         const baseDamage = Math.max(1, Math.floor((wbUser.combatState.monsterBuffedAttack || monster.attack) * 0.8) - stats.defense);
         state.damage = baseDamage * 2;
         if (auto) {
-            state.autoMsg = `🌀 ${skill.name}!`;
+            state.autoMsg = `🌀 ${skill.name}! Đánh 2 lần`;
         } else {
             state.monsterSkillMsg = `🌀 ${monster.name} dùng ${skill.name}! Tấn công 2 lần, mỗi đòn ${baseDamage} sát thương.`;
         }
@@ -12,7 +12,7 @@ export default function apply({ userId, monster, state }) {
         const baseDamage = Math.max(1, Math.floor(stats.attack * 0.8) - (wbUser.combatState.monsterBuffedDefense || monster.defense));
         state.damage = baseDamage * 2;
         if (auto) {
-            state.autoMsg = `🌀 Dùng ${skill.name}! 2 đòn, mỗi đòn ${baseDamage} sát thương (Tổng: ${state.damage})`;
+            state.autoMsg = `🌀 Dùng ${skill.name}! Đánh 2 lần`;
         } else {
             combatLog.push(`🌀 Bạn dùng ${skill.name}! Tấn công 2 lần, mỗi đòn ${baseDamage} sát thương.`);
             combatLog.push(`💥 Đòn 1: ${baseDamage} sát thương.`);

--- a/modules/commands/wb/skills/fireball.js
+++ b/modules/commands/wb/skills/fireball.js
@@ -5,15 +5,16 @@ export default function apply({ userId, monster, state }) {
         const targetResist = stats.magicResist || 0;
         state.damage = Math.max(1, Math.floor(magic * 1.5) - Math.floor(Math.max(0, targetResist) * 0.8));
         if (auto) {
-            state.autoMsg = `🔥 ${skill.name}!`;
+            state.autoMsg = `🔥 ${skill.name}! Sát thương phép`;
         } else {
             state.monsterSkillMsg = `🔥 ${monster.name} dùng ${skill.name}! Gây ${state.damage} sát thương phép.`;
         }
     } else {
         const targetResist = wbUser.combatState.monsterBuffedDefense || monster.magicResist || 0;
-        state.damage = Math.max(1, Math.floor(stats.magic * 1.5) - Math.floor(Math.max(0, targetResist - stats.armorPen) * 0.8));
+        const armorPen = stats.armorPen || 0;
+        state.damage = Math.max(1, Math.floor(stats.magic * 1.5) - Math.floor(Math.max(0, targetResist - armorPen) * 0.8));
         if (auto) {
-            state.autoMsg = `🔥 Dùng ${skill.name}! Gây ${state.damage} sát thương phép`;
+            state.autoMsg = `🔥 Dùng ${skill.name}! Sát thương phép`;
         } else {
             combatLog.push(`🔥 Bạn dùng ${skill.name}! Gây ${state.damage} sát thương phép.`);
             state.skillMessage = ` (Kỹ năng: ${skill.name})`;

--- a/modules/commands/wb/skills/freeze.js
+++ b/modules/commands/wb/skills/freeze.js
@@ -5,14 +5,14 @@ export default function apply({ userId, monster, state }) {
   if (isMonster) {
     addStatus(wbUser, 'freeze', 2);
     if (auto) {
-      state.autoMsg = `❄️ ${skill.name}!`;
+      state.autoMsg = `❄️ ${skill.name}! Đóng băng 2 lượt`;
     } else {
       state.monsterSkillMsg = `❄️ ${monster.name} dùng ${skill.name}!`;
     }
   } else {
     addStatus(wbUser.combatState, 'freeze', 2, undefined, 'monsterStatusEffects');
     if (auto) {
-      state.autoMsg = `❄️ Dùng ${skill.name}!`;
+      state.autoMsg = `❄️ Dùng ${skill.name}! Đóng băng 2 lượt`;
     } else {
       combatLog.push(`❄️ Bạn dùng ${skill.name}! Đóng băng kẻ địch.`);
       state.skillMessage = ` (Kỹ năng: ${skill.name})`;

--- a/modules/commands/wb/skills/paralyze.js
+++ b/modules/commands/wb/skills/paralyze.js
@@ -5,14 +5,14 @@ export default function apply({ userId, monster, state }) {
   if (isMonster) {
     addStatus(wbUser, 'paralyze', 2);
     if (auto) {
-      state.autoMsg = `⚡ ${skill.name}!`;
+      state.autoMsg = `⚡ ${skill.name}! Tê liệt 2 lượt`;
     } else {
       state.monsterSkillMsg = `⚡ ${monster.name} dùng ${skill.name}!`;
     }
   } else {
     addStatus(wbUser.combatState, 'paralyze', 2, undefined, 'monsterStatusEffects');
     if (auto) {
-      state.autoMsg = `⚡ Dùng ${skill.name}!`;
+      state.autoMsg = `⚡ Dùng ${skill.name}! Tê liệt 2 lượt`;
     } else {
       combatLog.push(`⚡ Bạn dùng ${skill.name}! Tê liệt kẻ địch.`);
       state.skillMessage = ` (Kỹ năng: ${skill.name})`;

--- a/modules/commands/wb/skills/poison.js
+++ b/modules/commands/wb/skills/poison.js
@@ -5,14 +5,14 @@ export default function apply({ userId, monster, state }) {
   if (isMonster) {
     addStatus(wbUser, 'poison', 3);
     if (auto) {
-      state.autoMsg = `☠️ ${skill.name}!`;
+      state.autoMsg = `☠️ ${skill.name}! Độc 3 lượt`;
     } else {
       state.monsterSkillMsg = `☠️ ${monster.name} dùng ${skill.name}!`;
     }
   } else {
     addStatus(wbUser.combatState, 'poison', 3, undefined, 'monsterStatusEffects');
     if (auto) {
-      state.autoMsg = `☠️ Dùng ${skill.name}!`;
+      state.autoMsg = `☠️ Dùng ${skill.name}! Độc 3 lượt`;
     } else {
       combatLog.push(`☠️ Bạn dùng ${skill.name}! Độc sẽ gây sát thương theo thời gian.`);
       state.skillMessage = ` (Kỹ năng: ${skill.name})`;

--- a/modules/commands/wb/skills/quicksand.js
+++ b/modules/commands/wb/skills/quicksand.js
@@ -5,14 +5,14 @@ export default function apply({ userId, monster, state }) {
   if (isMonster) {
     addStatus(wbUser, 'quicksand', 3);
     if (auto) {
-      state.autoMsg = `🕳️ ${skill.name}!`;
+      state.autoMsg = `🕳️ ${skill.name}! Sa lầy 3 lượt`;
     } else {
       state.monsterSkillMsg = `🕳️ ${monster.name} dùng ${skill.name}!`;
     }
   } else {
     addStatus(wbUser.combatState, 'quicksand', 3, undefined, 'monsterStatusEffects');
     if (auto) {
-      state.autoMsg = `🕳️ Dùng ${skill.name}!`;
+      state.autoMsg = `🕳️ Dùng ${skill.name}! Sa lầy 3 lượt`;
     } else {
       combatLog.push(`🕳️ Bạn dùng ${skill.name}! Làm kẻ địch sa lầy.`);
       state.skillMessage = ` (Kỹ năng: ${skill.name})`;

--- a/modules/commands/wb/skills/stun.js
+++ b/modules/commands/wb/skills/stun.js
@@ -5,14 +5,14 @@ export default function apply({ userId, monster, state }) {
   if (isMonster) {
     addStatus(wbUser, 'stun', 1);
     if (auto) {
-      state.autoMsg = `💫 ${skill.name}!`;
+      state.autoMsg = `💫 ${skill.name}! Choáng 1 lượt`;
     } else {
       state.monsterSkillMsg = `💫 ${monster.name} dùng ${skill.name}!`;
     }
   } else {
     addStatus(wbUser.combatState, 'stun', 1, undefined, 'monsterStatusEffects');
     if (auto) {
-      state.autoMsg = `💫 Dùng ${skill.name}!`;
+      state.autoMsg = `💫 Dùng ${skill.name}! Choáng 1 lượt`;
     } else {
       combatLog.push(`💫 Bạn dùng ${skill.name}! Làm choáng kẻ địch.`);
       state.skillMessage = ` (Kỹ năng: ${skill.name})`;


### PR DESCRIPTION
## Summary
- clarify manual combat logs by appending skill names to damage output
- clean up auto-combat logging and show damage separately
- add descriptive auto messages for status and buff skills

## Testing
- `node --test modules/commands/wb/skills/__tests__/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68973936c580832380046748ce1967a0